### PR TITLE
Update SA1200UsingDirectivesMustBePlacedCorrectly to not trigger in files with only global using directives

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/OrderingRules/SA1200CSharp10UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/OrderingRules/SA1200CSharp10UnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Contributors to the New StyleCop Analyzers project.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.CSharp10.OrderingRules
 {
     using System.Threading;
@@ -39,6 +37,31 @@ using System.Threading;
             };
 
             await VerifyCSharpFixAsync(testCode, expectedResults, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("\n")]
+        [InlineData("// A comment.\n")]
+        [WorkItem(3875, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3875")]
+        public async Task TestOnlyGlobalUsingStatementInFileAsync(string leadingTrivia)
+        {
+            var testCode = $@"{leadingTrivia}global using System;";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(3875, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3875")]
+        public async Task TestGlobalUsingStatementInFileWithNamespaceAsync()
+        {
+            var testCode = @"[|global using System;|]
+
+namespace TestNamespace
+{
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/OrderingRules/SA1200OutsideNamespaceCSharp10UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/OrderingRules/SA1200OutsideNamespaceCSharp10UnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Contributors to the New StyleCop Analyzers project.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.CSharp10.OrderingRules
 {
     using System.Threading;
@@ -35,6 +33,18 @@ namespace TestNamespace;
             };
 
             await VerifyCSharpFixAsync(testCode, expectedResults, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("\n")]
+        [InlineData("// A comment.\n")]
+        [WorkItem(3875, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3875")]
+        public async Task TestOnlyGlobalUsingStatementInFileAsync(string leadingTrivia)
+        {
+            var testCode = $@"{leadingTrivia}global using System;";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/OrderingRules/SA1200PreserveCSharp10UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/OrderingRules/SA1200PreserveCSharp10UnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Contributors to the New StyleCop Analyzers project.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.CSharp10.OrderingRules
 {
     using System.Threading;
@@ -38,6 +36,18 @@ using System.Threading;
 
 namespace TestNamespace;
 ";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("\n")]
+        [InlineData("// A comment.\n")]
+        [WorkItem(3875, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3875")]
+        public async Task TestOnlyGlobalUsingStatementInFileAsync(string leadingTrivia)
+        {
+            var testCode = $@"{leadingTrivia}global using System;";
 
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/UsingDirectiveSyntaxExtensions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/UsingDirectiveSyntaxExtensions.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Contributors to the New StyleCop Analyzers project.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Lightup
+{
+    using System;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+    internal static class UsingDirectiveSyntaxExtensions
+    {
+        private static readonly Func<UsingDirectiveSyntax, SyntaxToken> GlobalKeywordAccessor;
+        private static readonly Func<UsingDirectiveSyntax, SyntaxToken, UsingDirectiveSyntax> WithGlobalKeywordAccessor;
+
+        static UsingDirectiveSyntaxExtensions()
+        {
+            GlobalKeywordAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<UsingDirectiveSyntax, SyntaxToken>(typeof(UsingDirectiveSyntax), nameof(GlobalKeyword));
+            WithGlobalKeywordAccessor = LightupHelpers.CreateSyntaxWithPropertyAccessor<UsingDirectiveSyntax, SyntaxToken>(typeof(UsingDirectiveSyntax), nameof(GlobalKeyword));
+        }
+
+        public static SyntaxToken GlobalKeyword(this UsingDirectiveSyntax syntax)
+        {
+            return GlobalKeywordAccessor(syntax);
+        }
+
+        public static UsingDirectiveSyntax WithGlobalKeyword(this UsingDirectiveSyntax syntax, SyntaxToken globalKeyword)
+        {
+            return WithGlobalKeywordAccessor(syntax, globalKeyword);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1200UsingDirectivesMustBePlacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1200UsingDirectivesMustBePlacedCorrectly.cs
@@ -216,6 +216,7 @@ namespace StyleCop.Analyzers.OrderingRules
             CompilationUnitSyntax syntax = (CompilationUnitSyntax)context.Node;
 
             List<SyntaxNode> usingDirectives = new List<SyntaxNode>();
+            bool containsOnlyGlobalUsingDirectives = true;
             foreach (SyntaxNode child in syntax.ChildNodes())
             {
                 switch (child.Kind())
@@ -238,14 +239,23 @@ namespace StyleCop.Analyzers.OrderingRules
 
                 case SyntaxKind.UsingDirective:
                     usingDirectives.Add(child);
+                    bool isGlobalUsing = ((UsingDirectiveSyntax)child).GlobalKeyword().IsKind(SyntaxKind.GlobalKeyword);
+                    containsOnlyGlobalUsingDirectives = containsOnlyGlobalUsingDirectives && isGlobalUsing;
                     continue;
 
-                case SyntaxKind.ExternAliasDirective:
                 case SyntaxKind.NamespaceDeclaration:
                 case SyntaxKindEx.FileScopedNamespaceDeclaration:
+                case SyntaxKind.ExternAliasDirective:
                 default:
+                    containsOnlyGlobalUsingDirectives = false;
                     continue;
                 }
+            }
+
+            if (containsOnlyGlobalUsingDirectives)
+            {
+                // Suppress SA1200 if file only contains global using directives
+                return;
             }
 
             foreach (var directive in usingDirectives)


### PR DESCRIPTION
Cherry-picked the following pull request:
- https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3938
