### PR TITLE
Update SA1515SingleLineCommentMustBePrecededByBlankLine to not require a blank line at the start of an expression body

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1515CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1515CSharp7UnitTests.cs
@@ -36,5 +36,83 @@ public class ClassName
 
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
+
+        /// <summary>
+        /// Verifies that the analyzer does not fire in expression bodied property accessors.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        [WorkItem(3550, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3550")]
+        public async Task TestExpressionBodiedPropertyAccessorsAsync()
+        {
+            var testCode = @"
+class TestClass
+{
+    public int TestProperty
+    {
+        get =>
+            // A comment line
+            42;
+
+        set =>
+            // A comment line
+            _ = value;
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the analyzer does not fire in expression bodied indexer accessors.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        [WorkItem(3550, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3550")]
+        public async Task TestExpressionBodiedIndexerAccessorsAsync()
+        {
+            var testCode = @"
+class TestClass
+{
+    public int this[int i]
+    {
+        get =>
+            // A comment line
+            42;
+
+        set =>
+            // A comment line
+            _ = value;
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the analyzer does not fire in expression bodied event accessors.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        [WorkItem(3550, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3550")]
+        public async Task TestExpressionBodiedEventAccessorsAsync()
+        {
+            var testCode = @"
+class TestClass
+{
+    public event System.Action TestEvent
+    {
+        add =>
+            // A comment line
+            _ = value;
+
+        remove =>
+            // A comment line
+            _ = value;
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1515UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1515UnitTests.cs
@@ -301,5 +301,62 @@ class TestClass
 
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
+
+        /// <summary>
+        /// Verifies that the analyzer does not fire in expression bodied properties.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        [WorkItem(3550, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3550")]
+        public async Task TestExpressionBodiedPropertyAsync()
+        {
+            var testCode = @"
+class TestClass
+{
+    public int TestProperty =>
+        // A comment line
+        42;
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the analyzer does not fire in expression bodied indexers.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        [WorkItem(3550, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3550")]
+        public async Task TestExpressionBodiedIndexerAsync()
+        {
+            var testCode = @"
+class TestClass
+{
+    public int this[int i] =>
+        // A comment line
+        42;
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the analyzer does not fire in expression bodied methods.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        [WorkItem(3550, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3550")]
+        public async Task TestExpressionBodiedMethodAsync()
+        {
+            var testCode = @"
+class TestClass
+{
+    public int TestMethod(int x) =>
+        // A comment line
+        42;
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1515SingleLineCommentMustBePrecededByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1515SingleLineCommentMustBePrecededByBlankLine.cs
@@ -269,7 +269,8 @@ namespace StyleCop.Analyzers.LayoutRules
                 || (prevToken.IsKind(SyntaxKind.OpenBracketToken) && prevToken.Parent.IsKind(SyntaxKindEx.CollectionExpression))
                 || prevToken.Parent.IsKind(SyntaxKind.CaseSwitchLabel)
                 || prevToken.Parent.IsKind(SyntaxKindEx.CasePatternSwitchLabel)
-                || prevToken.Parent.IsKind(SyntaxKind.DefaultSwitchLabel);
+                || prevToken.Parent.IsKind(SyntaxKind.DefaultSwitchLabel)
+                || prevToken.IsKind(SyntaxKind.EqualsGreaterThanToken);
         }
 
         private static bool IsPrecededByDirectiveTrivia<T>(T triviaList, int triviaIndex)


### PR DESCRIPTION
 Cherry-picked the following pull request:
- https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3940
