### PR TITLE
Fix SA1514: Do not report when documenting types declared in the global namespace

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1514UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1514UnitTests.cs
@@ -1151,5 +1151,199 @@ public class TestClass
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
+
+        [Fact]
+        [WorkItem(3849, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3849")]
+        public async Task TestClassInGlobalNamespaceAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// X.
+/// </summary>
+public class TestClass
+{
+}
+";
+
+            var expected = DiagnosticResult.EmptyDiagnosticResults;
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestClassInGlobalNamespaceWithoutNewlineAsync()
+        {
+            var testCode = @"/// <summary>
+/// X.
+/// </summary>
+public class TestClass
+{
+}
+";
+
+            var expected = DiagnosticResult.EmptyDiagnosticResults;
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestClassInNamespaceAsync()
+        {
+            var testCode = @"
+namespace TestNamespace
+{
+    /// <summary>
+    /// X.
+    /// </summary>
+    public class TestClass
+    {
+    }
+}
+";
+
+            var expected = DiagnosticResult.EmptyDiagnosticResults;
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestClassInNamespaceWithCommentAsync()
+        {
+            var testCode = @"
+namespace TestNamespace
+{
+    // Normal comment
+    {|#0:///|} <summary>
+    /// X.
+    /// </summary>
+    public class TestClass
+    {
+    }
+}
+";
+
+            var fixedCode = @"
+namespace TestNamespace
+{
+    // Normal comment
+
+    /// <summary>
+    /// X.
+    /// </summary>
+    public class TestClass
+    {
+    }
+}
+";
+
+            var expected = new[]
+            {
+                Diagnostic().WithLocation(0).WithArguments(" not", "preceded"),
+            };
+
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestClassInGlobalNamespaceWithCommentAsync()
+        {
+            var testCode = @"
+// Normal comment
+{|#0:///|} <summary>
+/// X.
+/// </summary>
+public class TestClass
+{
+}
+";
+
+            var fixedCode = @"
+// Normal comment
+
+/// <summary>
+/// X.
+/// </summary>
+public class TestClass
+{
+}
+";
+
+            var expected = new[]
+            {
+                Diagnostic().WithLocation(0).WithArguments(" not", "preceded"),
+            };
+
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestClassInGlobalNamespaceWithPreprocessorDirectiveAsync()
+        {
+            var testCode = @"
+#if DEBUG
+#endif
+{|#0:///|} <summary>
+/// X.
+/// </summary>
+public class TestClass
+{
+}
+";
+
+            var fixedCode = @"
+#if DEBUG
+#endif
+
+/// <summary>
+/// X.
+/// </summary>
+public class TestClass
+{
+}
+";
+
+            var expected = new[]
+            {
+                Diagnostic().WithLocation(0).WithArguments(" not", "preceded"),
+            };
+
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestClassInGlobalNamespaceWithMultilineCommentAsync()
+        {
+            var testCode = @"
+/* Normal
+ * multiline
+ * comment */
+{|#0:///|} <summary>
+/// X.
+/// </summary>
+public class TestClass
+{
+}
+";
+
+            var fixedCode = @"
+/* Normal
+ * multiline
+ * comment */
+
+/// <summary>
+/// X.
+/// </summary>
+public class TestClass
+{
+}
+";
+
+            var expected = new[]
+            {
+                Diagnostic().WithLocation(0).WithArguments(" not", "preceded"),
+            };
+
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1514ElementDocumentationHeaderMustBePrecededByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1514ElementDocumentationHeaderMustBePrecededByBlankLine.cs
@@ -170,6 +170,13 @@ namespace StyleCop.Analyzers.LayoutRules
                     // no leading blank line necessary at start of scope.
                     return;
                 }
+
+                // Logic to handle global namespace case
+                if (prevToken.IsKind(SyntaxKind.None))
+                {
+                    // Node is the first element in the global namespace
+                    return;
+                }
             }
 
             context.ReportDiagnostic(Diagnostic.Create(Descriptor, GetDiagnosticLocation(documentationHeader)));


### PR DESCRIPTION
PR from DotNetAnalyzers/StyleCopAnalyzers#3863

Fixes DotNetAnalyzers/StyleCopAnalyzers#3849