### PR TITLE
Update SA1402FileMayOnlyContainASingleType to treat types with the file accessibility modifier as not relevant

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/MaintainabilityRules/SA1402ForClassCSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/MaintainabilityRules/SA1402ForClassCSharp11UnitTests.cs
@@ -3,9 +3,28 @@
 
 namespace StyleCop.Analyzers.Test.CSharp11.MaintainabilityRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp10.MaintainabilityRules;
+    using Xunit;
 
     public partial class SA1402ForClassCSharp11UnitTests : SA1402ForClassCSharp10UnitTests
     {
+        [Fact]
+        [WorkItem(3803, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3803")]
+        public async Task TestFileModifierAsync()
+        {
+            var testCode = $@"
+public class TestType1 {{ }}
+file class TestType2 {{ }}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(
+                testCode,
+                this.GetSettings(),
+                DiagnosticResult.EmptyDiagnosticResults,
+                CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/MaintainabilityRules/SA1402ForDelegateCSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/MaintainabilityRules/SA1402ForDelegateCSharp11UnitTests.cs
@@ -3,9 +3,28 @@
 
 namespace StyleCop.Analyzers.Test.CSharp11.MaintainabilityRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp10.MaintainabilityRules;
+    using Xunit;
 
     public partial class SA1402ForDelegateCSharp11UnitTests : SA1402ForDelegateCSharp10UnitTests
     {
+        [Fact]
+        [WorkItem(3803, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3803")]
+        public async Task TestFileModifierAsync()
+        {
+            var testCode = $@"
+public class TestType1 {{ }}
+file delegate void TestType2();
+";
+
+            await VerifyCSharpDiagnosticAsync(
+                testCode,
+                this.GetSettings(),
+                DiagnosticResult.EmptyDiagnosticResults,
+                CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/MaintainabilityRules/SA1402ForEnumCSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/MaintainabilityRules/SA1402ForEnumCSharp11UnitTests.cs
@@ -3,9 +3,28 @@
 
 namespace StyleCop.Analyzers.Test.CSharp11.MaintainabilityRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp10.MaintainabilityRules;
+    using Xunit;
 
     public partial class SA1402ForEnumCSharp11UnitTests : SA1402ForEnumCSharp10UnitTests
     {
+        [Fact]
+        [WorkItem(3803, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3803")]
+        public async Task TestFileModifierAsync()
+        {
+            var testCode = $@"
+public class TestType1 {{ }}
+file enum TestType2 {{ }}
+";
+
+            await VerifyCSharpDiagnosticAsync(
+                testCode,
+                this.GetSettings(),
+                DiagnosticResult.EmptyDiagnosticResults,
+                CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/MaintainabilityRules/SA1402ForInterfaceCSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/MaintainabilityRules/SA1402ForInterfaceCSharp11UnitTests.cs
@@ -3,9 +3,28 @@
 
 namespace StyleCop.Analyzers.Test.CSharp11.MaintainabilityRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp10.MaintainabilityRules;
+    using Xunit;
 
     public partial class SA1402ForInterfaceCSharp11UnitTests : SA1402ForInterfaceCSharp10UnitTests
     {
+        [Fact]
+        [WorkItem(3803, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3803")]
+        public async Task TestFileModifierAsync()
+        {
+            var testCode = $@"
+public class TestType1 {{ }}
+file interface TestType2 {{ }}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(
+                testCode,
+                this.GetSettings(),
+                DiagnosticResult.EmptyDiagnosticResults,
+                CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/MaintainabilityRules/SA1402ForRecordCSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/MaintainabilityRules/SA1402ForRecordCSharp11UnitTests.cs
@@ -3,9 +3,28 @@
 
 namespace StyleCop.Analyzers.Test.CSharp11.MaintainabilityRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp10.MaintainabilityRules;
+    using Xunit;
 
     public partial class SA1402ForRecordCSharp11UnitTests : SA1402ForRecordCSharp10UnitTests
     {
+        [Fact]
+        [WorkItem(3803, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3803")]
+        public async Task TestFileModifierAsync()
+        {
+            var testCode = $@"
+public class TestType1 {{ }}
+file record TestType2 {{ }}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(
+                testCode,
+                this.GetSettings(),
+                DiagnosticResult.EmptyDiagnosticResults,
+                CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/MaintainabilityRules/SA1402ForRecordClassCSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/MaintainabilityRules/SA1402ForRecordClassCSharp11UnitTests.cs
@@ -3,9 +3,28 @@
 
 namespace StyleCop.Analyzers.Test.CSharp11.MaintainabilityRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp10.MaintainabilityRules;
+    using Xunit;
 
     public partial class SA1402ForRecordClassCSharp11UnitTests : SA1402ForRecordClassCSharp10UnitTests
     {
+        [Fact]
+        [WorkItem(3803, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3803")]
+        public async Task TestFileModifierAsync()
+        {
+            var testCode = $@"
+public class TestType1 {{ }}
+file record class TestType2 {{ }}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(
+                testCode,
+                this.GetSettings(),
+                DiagnosticResult.EmptyDiagnosticResults,
+                CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/MaintainabilityRules/SA1402ForRecordStructCSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/MaintainabilityRules/SA1402ForRecordStructCSharp11UnitTests.cs
@@ -3,9 +3,28 @@
 
 namespace StyleCop.Analyzers.Test.CSharp11.MaintainabilityRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp10.MaintainabilityRules;
+    using Xunit;
 
     public partial class SA1402ForRecordStructCSharp11UnitTests : SA1402ForRecordStructCSharp10UnitTests
     {
+        [Fact]
+        [WorkItem(3803, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3803")]
+        public async Task TestFileModifierAsync()
+        {
+            var testCode = $@"
+public class TestType1 {{ }}
+file record struct TestType2 {{ }}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(
+                testCode,
+                this.GetSettings(),
+                DiagnosticResult.EmptyDiagnosticResults,
+                CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/MaintainabilityRules/SA1402ForStructCSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/MaintainabilityRules/SA1402ForStructCSharp11UnitTests.cs
@@ -3,9 +3,28 @@
 
 namespace StyleCop.Analyzers.Test.CSharp11.MaintainabilityRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp10.MaintainabilityRules;
+    using Xunit;
 
     public partial class SA1402ForStructCSharp11UnitTests : SA1402ForStructCSharp10UnitTests
     {
+        [Fact]
+        [WorkItem(3803, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3803")]
+        public async Task TestFileModifierAsync()
+        {
+            var testCode = $@"
+public class TestType1 {{ }}
+file struct TestType2 {{ }}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(
+                testCode,
+                this.GetSettings(),
+                DiagnosticResult.EmptyDiagnosticResults,
+                CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1402FileMayOnlyContainASingleType.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1402FileMayOnlyContainASingleType.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Contributors to the New StyleCop Analyzers project.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.MaintainabilityRules
 {
     using System;
@@ -111,30 +109,36 @@ namespace StyleCop.Analyzers.MaintainabilityRules
         private static bool IsRelevantType(SyntaxNode node, StyleCopSettings settings)
         {
             var topLevelTypes = settings.MaintainabilityRules.TopLevelTypes;
-            var isRelevant = false;
 
+            var isRelevant = false;
+            SyntaxTokenList modifiers = default;
             switch (node.Kind())
             {
             case SyntaxKind.ClassDeclaration:
             case SyntaxKindEx.RecordDeclaration:
                 isRelevant = topLevelTypes.Contains(TopLevelType.Class);
+                modifiers = ((BaseTypeDeclarationSyntax)node).Modifiers;
                 break;
             case SyntaxKind.InterfaceDeclaration:
                 isRelevant = topLevelTypes.Contains(TopLevelType.Interface);
+                modifiers = ((BaseTypeDeclarationSyntax)node).Modifiers;
                 break;
             case SyntaxKind.StructDeclaration:
             case SyntaxKindEx.RecordStructDeclaration:
                 isRelevant = topLevelTypes.Contains(TopLevelType.Struct);
+                modifiers = ((BaseTypeDeclarationSyntax)node).Modifiers;
                 break;
             case SyntaxKind.EnumDeclaration:
                 isRelevant = topLevelTypes.Contains(TopLevelType.Enum);
+                modifiers = ((BaseTypeDeclarationSyntax)node).Modifiers;
                 break;
             case SyntaxKind.DelegateDeclaration:
                 isRelevant = topLevelTypes.Contains(TopLevelType.Delegate);
+                modifiers = ((DelegateDeclarationSyntax)node).Modifiers;
                 break;
             }
 
-            return isRelevant;
+            return isRelevant && !modifiers.Any(x => x.IsKind(SyntaxKindEx.FileKeyword));
         }
     }
 }

--- a/documentation/SA1402.md
+++ b/documentation/SA1402.md
@@ -27,6 +27,8 @@ It is possible to configure which kind of types this rule should affect. By defa
 
 It is also possible to place multiple parts of the same partial type within the same file.
 
+Types with the `file` access modifier are not taken into account.
+
 ## How to fix violations
 
 To fix an instance of this violation, move each type into its own file.


### PR DESCRIPTION
Fixes https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3803