### PR TITLE
Update SA1003SymbolsMustBeSpacedCorrectly to allow a null forgiving operator last on a line

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1003CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1003CSharp8UnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Contributors to the New StyleCop Analyzers project.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.CSharp8.SpacingRules
 {
     using System.Threading;
@@ -99,8 +97,8 @@ namespace TestNamespace
 
             var expected = new[]
             {
-                    Diagnostic(DescriptorPrecededByWhitespace).WithLocation(0).WithArguments("??="),
-                    Diagnostic(DescriptorFollowedByWhitespace).WithLocation(0).WithArguments("??="),
+                Diagnostic(DescriptorPrecededByWhitespace).WithLocation(0).WithArguments("??="),
+                Diagnostic(DescriptorFollowedByWhitespace).WithLocation(0).WithArguments("??="),
             };
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
@@ -137,10 +135,32 @@ namespace TestNamespace
 
             var expected = new[]
             {
-                    Diagnostic(DescriptorNotPrecededByWhitespace).WithLocation(0).WithArguments("!"),
-                    Diagnostic(DescriptorNotFollowedByWhitespace).WithLocation(0).WithArguments("!"),
+                Diagnostic(DescriptorNotPrecededByWhitespace).WithLocation(0).WithArguments("!"),
+                Diagnostic(DescriptorNotFollowedByWhitespace).WithLocation(0).WithArguments("!"),
             };
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData(".Length")]
+        [InlineData("+ 'a'")]
+        public async Task TestNullForgivingOperatorLastAtLineAsync(string expr)
+        {
+            var testCode = $@"
+namespace TestNamespace
+{{
+    public class TestClass
+    {{
+        public void TestMethod(string? x)
+        {{
+            _ = x!
+                {expr};
+        }}
+    }}
+}}
+";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003SymbolsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003SymbolsMustBeSpacedCorrectly.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Contributors to the New StyleCop Analyzers project.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.SpacingRules
 {
     using System;
@@ -330,9 +328,11 @@ namespace StyleCop.Analyzers.SpacingRules
                 break;
             }
 
-            // If the next token is a close brace token we are in an anonymous object creation or an initialization.
-            // Then we allow a new line
-            bool allowEndOfLine = followingToken.IsKind(SyntaxKind.CloseBraceToken);
+            var isLastInAnonymousObjectCreationOrInitialization = followingToken.IsKind(SyntaxKind.CloseBraceToken);
+            var isConditionalAccessExpression = unaryExpression.IsKind(SyntaxKindEx.SuppressNullableWarningExpression);
+            var allowEndOfLine =
+                isLastInAnonymousObjectCreationOrInitialization ||
+                isConditionalAccessExpression;
 
             CheckToken(context, unaryExpression.OperatorToken, false, allowEndOfLine, mustHaveTrailingWhitespace);
         }
@@ -381,7 +381,7 @@ namespace StyleCop.Analyzers.SpacingRules
             CheckToken(context, arrowExpressionClause.ArrowToken, true, true, true);
         }
 
-        private static void CheckToken(SyntaxNodeAnalysisContext context, SyntaxToken token, bool withLeadingWhitespace, bool allowAtEndOfLine, bool withTrailingWhitespace, string tokenText = null)
+        private static void CheckToken(SyntaxNodeAnalysisContext context, SyntaxToken token, bool withLeadingWhitespace, bool allowAtEndOfLine, bool withTrailingWhitespace, string? tokenText = null)
         {
             tokenText = tokenText ?? token.Text;
 


### PR DESCRIPTION
Fixes  #11