### PR TITLE
Update SA1316 to always analyze explicit member names in tuple expressions

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/NamingRules/SA1316CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/NamingRules/SA1316CSharp7UnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Contributors to the New StyleCop Analyzers project.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.CSharp7.NamingRules
 {
     using System.Collections.Generic;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/NamingRules/SA1316CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/NamingRules/SA1316CSharp7UnitTests.cs
@@ -183,7 +183,7 @@ public class TestClass
         }
 
         /// <summary>
-        /// Validates the properly explicitly named tuple elements, even when using inferred tuple element names, will not produce diagnostics.
+        /// Validates that properly explicitly named tuple elements will not produce diagnostics.
         /// </summary>
         /// <param name="settings">The test settings to use.</param>
         /// <param name="tupleElementName1">The expected tuple element name for the first field.</param>
@@ -192,25 +192,47 @@ public class TestClass
         /// <param name="tupleInferred2">The name of the second tuple element that would be inferred if not given explicitly.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Theory]
+        [InlineData(CamelCaseTestSettings, "elementName1", "elementName2", "ElementValue1", "ElementValue2")]
         [InlineData(CamelCaseInferredTestSettings, "elementName1", "elementName2", "ElementValue1", "ElementValue2")]
+        [InlineData(PascalCaseTestSettings, "ElementName1", "ElementName2", "elementValue1", "elementValue2")]
         [InlineData(PascalCaseInferredTestSettings, "ElementName1", "ElementName2", "elementValue1", "elementValue2")]
-        public async Task ValidateProperCasedExplicitNamesEvenWithInferredTupleElementNamesAsync(string settings, string tupleElementName1, string tupleElementName2, string tupleInferred1, string tupleInferred2)
+        public async Task ValidateProperCasedExplicitTupleExpressionNamesAsync(string settings, string tupleElementName1, string tupleElementName2, string tupleInferred1, string tupleInferred2)
         {
             var testCode = $@"
 public class TestClass
 {{
-    public void TestMethod1()
+    public void TestMethod(int {tupleInferred1}, string {tupleInferred2})
     {{
-        var {tupleInferred1} = 1;
-        var {tupleInferred2} = ""test"";
         var tuple = ({tupleElementName1}: {tupleInferred1}, {tupleElementName2}: {tupleInferred2});
     }}
+}}
+";
 
-    public void TestMethod2()
+            await VerifyCSharpDiagnosticAsync(LanguageVersion.CSharp7_1.OrLaterDefault(), testCode, settings, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Validates that improperly explicitly named tuple elements will produce diagnostics.
+        /// </summary>
+        /// <param name="settings">The test settings to use.</param>
+        /// <param name="tupleElementName1">The expected tuple element name for the first field.</param>
+        /// <param name="tupleElementName2">The expected tuple element name for the second field.</param>
+        /// <param name="tupleInferred1">The name of the first tuple element that would be inferred if not given explicitly.</param>
+        /// <param name="tupleInferred2">The name of the second tuple element that would be inferred if not given explicitly.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [InlineData(CamelCaseTestSettings, "ElementName1", "ElementName2", "elementValue1", "elementValue2")]
+        [InlineData(CamelCaseInferredTestSettings, "ElementName1", "ElementName2", "elementValue1", "elementValue2")]
+        [InlineData(PascalCaseTestSettings, "elementName1", "elementName2", "ElementValue1", "ElementValue2")]
+        [InlineData(PascalCaseInferredTestSettings, "elementName1", "elementName2", "ElementValue1", "ElementValue2")]
+        public async Task ValidateImproperCasedExplicitTupleExpressionNamesAsync(string settings, string tupleElementName1, string tupleElementName2, string tupleInferred1, string tupleInferred2)
+        {
+            var testCode = $@"
+public class TestClass
+{{
+    public void TestMethod(int {tupleInferred1}, string {tupleInferred2})
     {{
-        var {tupleInferred1} = 1;
-        var {tupleElementName2} = ""test"";
-        var tuple = ({tupleElementName1}: {tupleInferred1}, {tupleElementName2});
+        var tuple = ({tupleElementName1}: [|{tupleInferred1}|], {tupleElementName2}: [|{tupleInferred2}|]);
     }}
 }}
 ";

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/LanguageFeatureHelpers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/LanguageFeatureHelpers.cs
@@ -43,6 +43,7 @@ namespace StyleCop.Analyzers.Helpers
         /// <returns>True if inferred tuple names are supported by the compiler.</returns>
         internal static bool SupportsInferredTupleElementNames(this SyntaxNodeAnalysisContext context)
         {
+            // TODO: Shouldn't this be based on the Roslyn version instead of selected language version?
             var csharpParseOptions = context.Node.SyntaxTree.Options as CSharpParseOptions;
             return (csharpParseOptions != null) && (csharpParseOptions.LanguageVersion >= LanguageVersionEx.CSharp7_1);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1316TupleElementNamesShouldUseCorrectCasing.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1316TupleElementNamesShouldUseCorrectCasing.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Contributors to the New StyleCop Analyzers project.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.NamingRules
 {
     using System;
@@ -95,7 +93,7 @@ namespace StyleCop.Analyzers.NamingRules
             }
         }
 
-        private static string TryGetMemberName(ArgumentSyntax argument, StyleCopSettings settings)
+        private static string? TryGetMemberName(ArgumentSyntax argument, StyleCopSettings settings)
         {
             var explicitName = argument.NameColon?.Name.Identifier.ValueText;
             if (explicitName != null)
@@ -122,7 +120,7 @@ namespace StyleCop.Analyzers.NamingRules
             CheckName(context, settings, tupleElement.SyntaxNode, tupleElement.Identifier.ValueText, tupleElement.Identifier.GetLocation(), true);
         }
 
-        private static void CheckName(SyntaxNodeAnalysisContext context, StyleCopSettings settings, SyntaxNode tupleElement, string tupleElementName, Location location, bool prepareCodeFix)
+        private static void CheckName(SyntaxNodeAnalysisContext context, StyleCopSettings settings, SyntaxNode? tupleElement, string tupleElementName, Location location, bool prepareCodeFix)
         {
             if (tupleElementName == "_")
             {
@@ -172,7 +170,7 @@ namespace StyleCop.Analyzers.NamingRules
         /// When overriding a base class or implementing an interface, the compiler requires the names to match
         /// the original definition. This method checks if we are allowed to change the name of the specified tuple element.
         /// </summary>
-        private static bool CanTupleElementNameBeChanged(SyntaxNodeAnalysisContext context, SyntaxNode tupleElement)
+        private static bool CanTupleElementNameBeChanged(SyntaxNodeAnalysisContext context, SyntaxNode? tupleElement)
         {
             var memberDeclaration = GetAncestorMemberDeclaration(tupleElement);
             if (memberDeclaration == null)
@@ -198,7 +196,7 @@ namespace StyleCop.Analyzers.NamingRules
         /// Returns the ancestor <see cref="MemberDeclarationSyntax"/>, if the node is part of its "signature",
         /// otherwise returns null.
         /// </summary>
-        private static MemberDeclarationSyntax GetAncestorMemberDeclaration(SyntaxNode node)
+        private static MemberDeclarationSyntax? GetAncestorMemberDeclaration(SyntaxNode? node)
         {
             // NOTE: Avoiding a simple FirstAncestorOrSelf<MemberDeclarationSyntax>() call here, since
             // that would also return true for e.g. tuple variable declarations inside a method body.


### PR DESCRIPTION
Fixes #28