### PR TITLE
Update SA1413CodeFixProvider to handle nested diagnostics in a single pass

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/MaintainabilityRules/SA1413CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/MaintainabilityRules/SA1413CodeFixProvider.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Contributors to the New StyleCop Analyzers project.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.MaintainabilityRules
 {
     using System.Collections.Immutable;
@@ -50,11 +48,9 @@ namespace StyleCop.Analyzers.MaintainabilityRules
 
         private static async Task<Document> GetTransformedDocumentAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
         {
-            var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            var syntaxNode = syntaxRoot.FindNode(diagnostic.Location.SourceSpan);
-
-            TextChange textChange = new TextChange(diagnostic.Location.SourceSpan, syntaxNode.ToString() + ",");
+            var textSpan = new TextSpan(diagnostic.Location.SourceSpan.End, 0);
+            var textChange = new TextChange(textSpan, ",");
             return document.WithText(text.WithChanges(textChange));
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1413UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1413UnitTests.cs
@@ -516,5 +516,69 @@ class TestClass
 
             await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
         }
+
+        /// <summary>
+        /// Verifies that the code fix handles nested diagnostics in a single pass.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task VerifyNestedDiagnosticsFixAsync()
+        {
+            var testCode = @"
+class TestClass
+{
+    void Foo()
+    {
+        var test = new
+        {
+            MyArray = new[]
+            {
+                new
+                {
+                    MyProp = ""Test""
+                },
+                new
+                {
+                    MyProp = ""asdf""
+                }
+            }
+        };
+    }
+}
+";
+
+            var fixedTestCode = @"
+class TestClass
+{
+    void Foo()
+    {
+        var test = new
+        {
+            MyArray = new[]
+            {
+                new
+                {
+                    MyProp = ""Test"",
+                },
+                new
+                {
+                    MyProp = ""asdf"",
+                },
+            },
+        };
+    }
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithSpan(8, 13, 18, 14),
+                Diagnostic().WithSpan(12, 21, 12, 36),
+                Diagnostic().WithSpan(14, 17, 17, 18),
+                Diagnostic().WithSpan(16, 21, 16, 36),
+            };
+
+            await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }


### PR DESCRIPTION
Fixes #61