### PR TITLE
Update SA1000 to handle the c# 11's scoped keyword and add tests for some other rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,4 +129,4 @@ pinned to 10 for the codebase itself regardless of the C# versions being analyze
 
 `DOCUMENTATION.md` and the per-area pages under `documentation/` (`SpacingRules.md`, `OrderingRules.md`, etc.) are
 the index of implemented rules; `documentation/SAxxxx.md` files are the per-rule reference docs and their diagnostic
-`HelpLink` targets. Keep both in sync when adding, renaming, or removing a rule.
+`HelpLink` targets. Keep both in sync when adding, renaming, removing, or updating a rule.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/NamingRules/SA1305CSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/NamingRules/SA1305CSharp11UnitTests.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Contributors to the New StyleCop Analyzers project.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp11.NamingRules
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.CSharp6.Verifiers.StyleCopDiagnosticVerifier<
+        StyleCop.Analyzers.NamingRules.SA1305FieldNamesMustNotUseHungarianNotation>;
+
+    public partial class SA1305CSharp11UnitTests
+    {
+        [Fact]
+        public async Task TestScopedRefLocalWithHungarianNotationAsync()
+        {
+            var testCode = @"
+public class TestClass
+{
+    public void Bar()
+    {
+        int value = 5;
+        scoped ref int {|#0:baR|} = ref value;
+    }
+}
+";
+
+            var expected = Diagnostic().WithArguments("variable", "baR").WithLocation(0);
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(true);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/NamingRules/SA1312CSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/NamingRules/SA1312CSharp11UnitTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Contributors to the New StyleCop Analyzers project.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp11.NamingRules
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.CSharp6.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.NamingRules.SA1312VariableNamesMustBeginWithLowerCaseLetter,
+        StyleCop.Analyzers.NamingRules.RenameToLowerCaseCodeFixProvider>;
+
+    public partial class SA1312CSharp11UnitTests
+    {
+        [Fact]
+        public async Task TestScopedRefLocalStartingWithUpperCaseLetterAsync()
+        {
+            var testCode = @"
+public class TestClass
+{
+    public void Bar()
+    {
+        int value = 5;
+        scoped ref int {|#0:Bar|} = ref value;
+    }
+}
+";
+
+            var fixedCode = @"
+public class TestClass
+{
+    public void Bar()
+    {
+        int value = 5;
+        scoped ref int bar = ref value;
+    }
+}
+";
+
+            var expected = Diagnostic().WithArguments("Bar").WithLocation(0);
+
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(true);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/NamingRules/SA1313CSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/NamingRules/SA1313CSharp11UnitTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Contributors to the New StyleCop Analyzers project.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp11.NamingRules
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.CSharp6.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.NamingRules.SA1313ParameterNamesMustBeginWithLowerCaseLetter,
+        StyleCop.Analyzers.NamingRules.RenameToLowerCaseCodeFixProvider>;
+
+    public partial class SA1313CSharp11UnitTests
+    {
+        [Fact]
+        public async Task TestScopedParameterStartingWithUpperCaseLetterAsync()
+        {
+            var testCode = @"
+public class TestClass
+{
+    public void Bar(scoped System.Span<int> {|#0:Value|})
+    {
+    }
+}
+";
+
+            var fixedCode = @"
+public class TestClass
+{
+    public void Bar(scoped System.Span<int> value)
+    {
+    }
+}
+";
+
+            var expected = Diagnostic().WithArguments("Value").WithLocation(0);
+
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(true);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/ReadabilityRules/SA1121CSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/ReadabilityRules/SA1121CSharp11UnitTests.cs
@@ -5,6 +5,7 @@ namespace StyleCop.Analyzers.Test.CSharp11.ReadabilityRules
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using Xunit;
 
     using static StyleCop.Analyzers.Test.CSharp6.Verifiers.StyleCopCodeFixVerifier<
@@ -38,6 +39,38 @@ class TestClass
                 TestSources = { source1, oldSource2 },
                 FixedSources = { source1, newSource2 },
             }.RunAsync(CancellationToken.None).ConfigureAwait(true);
+        }
+
+        [Fact]
+        public async Task TestScopedRefLocalDeclarationAsync()
+        {
+            var testCode = @"namespace System
+{
+    public class Foo
+    {
+        public void Bar()
+        {
+            int value = 5;
+            scoped ref [|Int32|] test = ref value;
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace System
+{
+    public class Foo
+    {
+        public void Bar()
+        {
+            int value = 5;
+            scoped ref int test = ref value;
+        }
+    }
+}
+";
+
+            await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, fixedCode, CancellationToken.None).ConfigureAwait(true);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/SpacingRules/SA1000CSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/SpacingRules/SA1000CSharp11UnitTests.cs
@@ -45,5 +45,33 @@ public class MyClass
             };
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(true);
         }
+
+        [Fact]
+        public async Task TestScopedLocalDeclarationAsync()
+        {
+            var testCode = @"
+public class TestClass
+{
+    public void Method()
+    {
+        {|#0:scoped|}@System.Span<int> test = default;
+    }
+}
+";
+
+            var fixedCode = @"
+public class TestClass
+{
+    public void Method()
+    {
+        scoped @System.Span<int> test = default;
+    }
+}
+";
+
+            var expected = Diagnostic().WithArguments("scoped", string.Empty, "followed").WithLocation(0);
+
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(true);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/SpacingRules/SA1001CSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/SpacingRules/SA1001CSharp11UnitTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Contributors to the New StyleCop Analyzers project.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp11.SpacingRules
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.CSharp6.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.SpacingRules.SA1001CommasMustBeSpacedCorrectly,
+        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+
+    public partial class SA1001CSharp11UnitTests
+    {
+        [Fact]
+        public async Task TestScopedParameterAsync()
+        {
+            var testCode = @"
+public class TestClass
+{
+    public void Method(int a{|#0:,|}scoped System.Span<int> b)
+    {
+    }
+}
+";
+
+            var fixedCode = @"
+public class TestClass
+{
+    public void Method(int a, scoped System.Span<int> b)
+    {
+    }
+}
+";
+
+            var expected = Diagnostic().WithArguments(string.Empty, "followed").WithLocation(0);
+
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(true);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/SpacingRules/SA1008CSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/SpacingRules/SA1008CSharp11UnitTests.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Contributors to the New StyleCop Analyzers project.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp11.SpacingRules
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+    using static StyleCop.Analyzers.SpacingRules.SA1008OpeningParenthesisMustBeSpacedCorrectly;
+    using static StyleCop.Analyzers.Test.CSharp6.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.SpacingRules.SA1008OpeningParenthesisMustBeSpacedCorrectly,
+        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+
+    public partial class SA1008CSharp11UnitTests
+    {
+        [Fact]
+        public async Task TestScopedParameterAsync()
+        {
+            var testCode = @"
+public class TestClass
+{
+    public void Method {|#0:(|}scoped System.Span<int> value)
+    {
+    }
+}
+";
+
+            var fixedCode = @"
+public class TestClass
+{
+    public void Method(scoped System.Span<int> value)
+    {
+    }
+}
+";
+
+            var expected = Diagnostic(DescriptorNotPreceded).WithLocation(0);
+
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(true);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp14/SpacingRules/SA1000CSharp14UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp14/SpacingRules/SA1000CSharp14UnitTests.cs
@@ -114,5 +114,37 @@ public class TestClass
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(true);
         }
+
+        [Fact]
+        public async Task TestSimpleLambdaParameterWithScopedModifierAsync()
+        {
+            var testCode = @"
+public delegate void ScopedSpanAction(scoped System.Span<int> value);
+
+public class TestClass
+{
+    public void Method()
+    {
+        ScopedSpanAction action = ({|#0:scoped|}@x) => { };
+    }
+}
+";
+
+            var fixedCode = @"
+public delegate void ScopedSpanAction(scoped System.Span<int> value);
+
+public class TestClass
+{
+    public void Method()
+    {
+        ScopedSpanAction action = (scoped @x) => { };
+    }
+}
+";
+
+            var expected = Diagnostic().WithArguments("scoped", string.Empty, "followed").WithLocation(0);
+
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(true);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/SyntaxKindEx.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/SyntaxKindEx.cs
@@ -16,6 +16,7 @@ namespace StyleCop.Analyzers.Lightup
         public const SyntaxKind ManagedKeyword = (SyntaxKind)8445;
         public const SyntaxKind UnmanagedKeyword = (SyntaxKind)8446;
         public const SyntaxKind RequiredKeyword = (SyntaxKind)8447;
+        public const SyntaxKind ScopedKeyword = (SyntaxKind)8448;
         public const SyntaxKind FileKeyword = (SyntaxKind)8449;
         public const SyntaxKind UnionKeyword = (SyntaxKind)8452;
         public const SyntaxKind NullableKeyword = (SyntaxKind)8486;
@@ -73,6 +74,7 @@ namespace StyleCop.Analyzers.Lightup
         public const SyntaxKind PrimaryConstructorBaseType = (SyntaxKind)9065;
         public const SyntaxKind FunctionPointerUnmanagedCallingConventionList = (SyntaxKind)9066;
         public const SyntaxKind RecordStructDeclaration = (SyntaxKind)9068;
+        public const SyntaxKind ScopedType = (SyntaxKind)9075;
         public const SyntaxKind CollectionExpression = (SyntaxKind)9076;
         public const SyntaxKind ExtensionBlockDeclaration = (SyntaxKind)9079;
         public const SyntaxKind WithElement = (SyntaxKind)9081;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
@@ -21,9 +21,9 @@ namespace StyleCop.Analyzers.SpacingRules
     /// <strong>fixed</strong>, <strong>for</strong>, <strong>foreach</strong>, <strong>from</strong>,
     /// <strong>group</strong>, <strong>if</strong>, <strong>in</strong>, <strong>into</strong>, <strong>join</strong>,
     /// <strong>let</strong>, <strong>lock</strong>, <strong>orderby</strong>, <strong>out</strong>,
-    /// <strong>ref</strong>, <strong>return</strong>, <strong>select</strong>, <strong>switch</strong>,
-    /// <strong>throw</strong>, <strong>using</strong>, <strong>var</strong>, <strong>where</strong>,
-    /// <strong>while</strong>, <strong>yield</strong>.</para>
+    /// <strong>ref</strong>, <strong>return</strong>, <strong>scoped</strong>, <strong>select</strong>,
+    /// <strong>switch</strong>, <strong>throw</strong>, <strong>using</strong>, <strong>var</strong>,
+    /// <strong>where</strong>, <strong>while</strong>, <strong>yield</strong>.</para>
     ///
     /// <para>The following keywords should not be followed by any space: <strong>checked</strong>,
     /// <strong>default</strong>, <strong>sizeof</strong>, <strong>typeof</strong>, <strong>unchecked</strong>.</para>
@@ -103,6 +103,7 @@ namespace StyleCop.Analyzers.SpacingRules
                 case SyntaxKind.OrderByKeyword:
                 case SyntaxKind.OutKeyword:
                 case SyntaxKind.RefKeyword:
+                case SyntaxKindEx.ScopedKeyword:
                 case SyntaxKind.SelectKeyword:
                 case SyntaxKind.SwitchKeyword:
                 case SyntaxKind.UsingKeyword:

--- a/documentation/SA1000.md
+++ b/documentation/SA1000.md
@@ -24,8 +24,8 @@ The spacing around a C# keyword is incorrect.
 A violation of this rule occurs when the spacing around a keyword is incorrect.
 
 The following C# keywords should always be followed by a single space: `and`, `await`, `case`, `catch`, `fixed`, `for`,
-`foreach`, `from`, `group`, `if`, `in`, `is`, `into`, `join`, `let`, `lock`, `not`, `orderby`, `or`, `out`, `ref`, `return`, `select`,
-`switch`, `using`, `var`, `where`, `while`, `yield`.
+`foreach`, `from`, `group`, `if`, `in`, `is`, `into`, `join`, `let`, `lock`, `not`, `orderby`, `or`, `out`, `ref`, `return`, `scoped`,
+`select`, `switch`, `using`, `var`, `where`, `while`, `yield`.
 
 The following keywords should not be followed by any space: `checked`, `default`, `nameof`, `sizeof`, `typeof`, `unchecked`.
 


### PR DESCRIPTION
Fixes #94